### PR TITLE
Revert to JAVA 8, docker, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,41 @@ vagrant up --provision
 ```
 to trigger it again.
 
-Also, this step (as well as the first start) involves several updates aand might take time depending on internet connection. 
+Also, this step (as well as the first start) involves several updates and it might take time depending on internet connection.
+
+### Note about Java SDK version
+Once provisioning completed, it could be needed to choose the JAVA SDK version to be used. 
+
+For pokemon_challenge project it is OpenJDK 1.8.
+```shell script
+vagrant ssh
+
+[vagrant@localhost ~]$ sudo update-alternatives --config java
+
+There are 2 programs which provide 'java'.
+
+  Selection    Command
+-----------------------------------------------
+*+ 1           java-1.8.0-openjdk.x86_64 (/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.262.b10-0.el7_8.x86_64/jre/bin/java)
+   2           java-11-openjdk.x86_64 (/usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/java)
+
+Enter to keep the current selection[+], or type selection number: 1
+```
+
+#### Why OpenJDK 1.8 ?
+This version is able to complete a Docker image build (which have been tested and working). 
+
+It is still tolerated but deprecated, as a warning shows you during server start. 
+
+#### Why OpenJDK 11 ?
+This is the version that will be supported in the future and new projects should use this one.
+
+However it seems as there are issues when using this version to build a Docker image with Maven and Quarkus Docker plugin.
+
+### Note about Docker installation
+Docker is installed using a convenience script, following [Docker official site guide](https://docs.docker.com/engine/install/centos/#install-using-the-convenience-script)
+
+Reason is that it is the faster way to automate Docker installation however this is not suited for a Production environment and downloaded script should always be inspected before execution. 
 
 ## SSH connectiviy
 
@@ -57,13 +91,21 @@ To open a shell to the Virtual Machine once started:
 ```shell script
 vagrant ssh
 ```
-## Source code and compilation
+## Source code 
 
 The source code should normally be available under:
 ```shell script
 cd /home/vagrant/workspace
 ```
 And it should be mapped on src folder within this repository, in the Host.
+
+From the virtual machine you should be able to clone the Pokemon Challenge repository as following:
+```shell script
+cd /home/vagrant/workspace
+git clone https://github.com/fmelpignano/pokemon_challenge.git 
+```
+
+To know more about Pokemon Challenge project, please refer to its [README page](https://github.com/fmelpignano/pokemon_challenge/blob/main/README.md)
 
 ## Stop
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "./src", "/home/vagrant/workspace/truelayer"
   
   config.vm.provider "virtualbox" do |v|
-    v.name = "truelayer_11"
+    v.name = "truelayer_8"
     v.memory = "2048"
     v.cpus = "2"
   end

--- a/provision.sh
+++ b/provision.sh
@@ -23,8 +23,8 @@ sudo yum -y install unzip
 # To create Git Repositories
 sudo yum -y install git
 
-echo "Installing OpenJdk 11"
-sudo yum install -y java-11-openjdk-devel
+echo "Installing OpenJdk 1.8"
+sudo yum install -y java-1.8-openjdk-devel
 
 # Maven 3.6.3 and higher required to use Quarkus
 echo "Installing Maven 3.6.3"
@@ -50,12 +50,20 @@ QUARKUS_ENV_FILE=/etc/profile.d/env_vars_quarkus.sh
 if [ ! -f "$QUARKUS_ENV_FILE" ]; then
     echo "$QUARKUS_ENV_FILE does not exist."
 	sudo bash -c 'cat <<EOF > /etc/profile.d/env_vars_quarkus.sh
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.262.b10-0.el7_8.x86_64/
 export PATH=\$PATH:\$JAVA_HOME/bin
 export M2_HOME=/opt/maven
 export MAVEN_HOME=$M2_HOME
 export PATH=$M2_HOME/bin:$PATH
 EOF'
 fi
+
+# For Docker image generation
+# https://docs.docker.com/engine/install/centos/#install-using-the-convenience-script
+# Not for production purpose! 
+curl -fsSL https://get.docker.com/ | sh
+sudo systemctl start docker
+sudo systemctl status docker
+sudo systemctl enable docker
 
 # https://www.graalvm.org/docs/getting-started-with-graalvm/linux/


### PR DESCRIPTION
Provisioning back to JAVA 1.8, to enable Quarkus Docker build.
Added Docker installation.
Provided further documentation.